### PR TITLE
Allow setting default user agent option

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -34,6 +34,7 @@ class Client implements HttpClient {
     const OP_VERBOSITY = 'op.verbosity';
     const OP_COMBINE_COOKIES = 'op.combine-cookies';
     const OP_CRYPTO = 'op.crypto';
+    const OP_DEFAULT_USER_AGENT = 'op.default-user-agent';
 
     const VERBOSE_NONE = 0b00;
     const VERBOSE_SEND = 0b01;
@@ -67,6 +68,7 @@ class Client implements HttpClient {
         self::OP_VERBOSITY => self::VERBOSE_NONE,
         self::OP_COMBINE_COOKIES => true,
         self::OP_CRYPTO => [],
+        self::OP_DEFAULT_USER_AGENT => null,
     ];
 
     public function __construct(
@@ -325,7 +327,8 @@ class Client implements HttpClient {
 
     private function normalizeRequestUserAgent(Request $request, array $options) {
         if (!$request->hasHeader('User-Agent')) {
-            $request->setHeader('User-Agent', self::USER_AGENT);
+            $userAgent = $options[self::OP_DEFAULT_USER_AGENT] ?: self::USER_AGENT;
+            $request->setHeader('User-Agent', $userAgent);
         }
     }
 


### PR DESCRIPTION
Adds support for setting a default user agent to override the Artax UA.

The reason for this is so that API clients can specify the library sending requests instead of the underlying HTTP client doing the "leg work". This would provide an easy way for these clients to set the UA on every request it sends.

I didn't provide a test because there were slim pickins' in the existing test. I wouldn't mind writing a test for this but would probably need some guidance on the best way to approach that.