### PR TITLE
Fixes README and setOption for OP_DEFAULT_USER_AGENT

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ A brief summary of the available options follows.
 | OP_VERBOSITY                | A bitmask of client constants controlling raw message output to the console. |
 | OP_COMBINE_COOKIES          | A boolean (default: `true`) controlling whether or not cookie headers are combined into a single header when sending requests. |
 | OP_CRYPTO                   | An array controlling TLS encryption options. |
+| OP_DEFAULT_USER_AGENT       | A string that will be set for each request's User-Agent if one has not already been provided. |
 
 
 ### Miscellaneous

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -487,7 +487,7 @@ class Client implements HttpClient {
                 } else {
                     $this->assignParsedResponse($cycle, $parsedResponseArr);
                 }
-                
+
                 if ($cycle->parser->getBuffer()) {
                     $this->reactor->immediately(function() use ($cycle) {
                         $this->parseSocketData($cycle);
@@ -991,6 +991,9 @@ class Client implements HttpClient {
                 break;
             case self::OP_CRYPTO:
                 $this->options[self::OP_CRYPTO] = (array) $value;
+                break;
+            case self::OP_DEFAULT_USER_AGENT:
+                $this->options[self::OP_DEFAULT_USER_AGENT] = (string) $value;
                 break;
             default:
                 throw new \DomainException(


### PR DESCRIPTION
My initial PR missed the appropriate case for `setOption`. This PR fixes that bug and updates README.