### PR TITLE
Fix improper type parser

### DIFF
--- a/lib/Uri.php
+++ b/lib/Uri.php
@@ -17,46 +17,46 @@ class Uri {
 
     public function __construct($uri) {
         $uri = (string) $uri;
-        
+
         if (!$parts = $this->parse($uri)) {
             throw new \DomainException(
                 'Invalid URI specified at ' . get_class($this) . '::__construct Argument 1'
             );
         }
-        
+
         $this->uri = $uri;
-        
+
         foreach ($parts as $key => $value) {
             $this->{$key} = $value;
         }
-        
+
         // http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.1
         // "schemes are case-insensitive"
         $this->scheme = strtolower($this->scheme);
-        
+
         // http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.2
-        // "Although host is case-insensitive, producers and normalizers should use lowercase for 
+        // "Although host is case-insensitive, producers and normalizers should use lowercase for
         // registered names and hexadecimal addresses for the sake of uniformity"
         $this->host = strtolower($this->host);
-        
+
         if ($this->port && $this->scheme) {
             $this->normalizeDefaultPort();
         }
-        
+
         if (filter_var($this->host, FILTER_VALIDATE_URL, FILTER_FLAG_IPV4)) {
             $this->isIpV4 = true;
         } elseif (filter_var($this->host, FILTER_VALIDATE_URL, FILTER_FLAG_IPV6)) {
             $this->isIpV6 = true;
         }
-        
+
         $this->parseQueryParameters();
-        
+
         if ($this->fragment) {
             $this->fragment = rawurldecode($this->fragment);
             $this->fragment = rawurlencode($this->fragment);
         }
     }
-    
+
     private function parse($uri) {
         // PHP 5.4.7 fixed the incorrect parsing of network path references
         // @codeCoverageIgnoreStart
@@ -66,32 +66,32 @@ class Uri {
         // @codeCoverageIgnoreEnd
 
         $isPhp533 = PHP_VERSION_ID >= 50303;
-        
+
         // PHP < 5.3.3 triggers E_WARNING on failure
         $parts = $isPhp533 ? parse_url($uri) : @parse_url($uri);
-        
+
         // If no path is present or it's not a network path reference we're finished
         if (!isset($parts['path']) || substr($parts['path'], 0, 2) !== '//') {
             return $parts;
         }
-        
+
         $schemeExists = isset($parts['scheme']);
         $tmpScheme = $schemeExists ? $parts['scheme'] : 'scheme';
-        
+
         $tmpUri = $tmpScheme . ':' . $parts['path'];
         $tmpParts = $isPhp533 ? parse_url($tmpUri) : @parse_url($tmpUri);
-        
+
         $parts['host'] = $tmpParts['host'];
-        
+
         if (isset($tmpParts['path'])) {
             $parts['path'] = $tmpParts['path'];
         } else {
             unset($parts['path']);
         }
-        
+
         return $parts;
     }
-    
+
     public function __toString() {
         return $this->reconstitute(
             $this->scheme,
@@ -101,52 +101,52 @@ class Uri {
             $this->fragment
         );
     }
-    
+
     /**
      * @link http://tools.ietf.org/html/rfc3986#section-5.3
      */
     private function reconstitute($scheme, $authority, $path, $query, $fragment) {
         $result = '';
-            
+
         if ($scheme) {
             $result .= $scheme . ':';
         }
-    
+
         if ($authority) {
             $result .= '//';
             $result .= $authority;
         }
-        
+
         $result .= $path;
-    
+
         if ($query) {
             $result .= '?';
             $result .= $query;
         }
-    
+
         if ($fragment) {
             $result .= '#';
             $result .= $fragment;
         }
-    
+
         return $result;
     }
-    
+
     /**
      * Normalizes the URI for maximal comparison success
-     * 
+     *
      * @return string
      */
     public function normalize() {
         if (!$this->uri) {
             return '';
         }
-        
+
         $path = $this->path ?: '/';
         $path = $this->removeDotSegments($path);
         $path = $this->decodeUnreservedCharacters($path);
         $path = $this->decodeReservedSubDelimiters($path);
-        
+
         return $this->reconstitute(
             $this->scheme,
             $this->getAuthority(),
@@ -155,11 +155,11 @@ class Uri {
             $this->fragment
         );
     }
-    
+
     /**
-     * "URI producers and normalizers should omit the port component and its ":" delimiter if port 
+     * "URI producers and normalizers should omit the port component and its ":" delimiter if port
      * is empty or if its value would be the same as that of the scheme's default."
-     * 
+     *
      * @link http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.3
      */
     private function normalizeDefaultPort() {
@@ -181,20 +181,20 @@ class Uri {
                 break;
         }
     }
-    
+
     /**
      * @link http://www.apps.ietf.org/rfc/rfc3986.html#sec-5.2.4
      */
     private function removeDotSegments($input) {
         $output = '';
-        
+
         $patternA  = ',^(\.\.?/),';
         $patternB1 = ',^(/\./),';
         $patternB2 = ',^(/\.)$,';
         $patternC  = ',^(/\.\./|/\.\.),';
         // $patternD  = ',^(\.\.?)$,';
         $patternE  = ',(/*[^/]*),';
-        
+
         while ($input !== '') {
             if (preg_match($patternA, $input)) {
                 $input = preg_replace($patternA, '', $input);
@@ -214,17 +214,17 @@ class Uri {
 
         return $output;
     }
-    
+
     /**
      * @link http://www.apps.ietf.org/rfc/rfc3986.html#sec-2.3
      */
     private function decodeUnreservedCharacters($str) {
         $str = rawurldecode($str);
         $str = rawurlencode($str);
-        
+
         $encoded = array('%2F', '%3A', '%40');
         $decoded = array('/', ':', '@');
-        
+
         return str_replace($encoded, $decoded, $str);
     }
 
@@ -234,10 +234,10 @@ class Uri {
     private function decodeReservedSubDelimiters($str) {
         $encoded = array('%21', '%24', '%26', '%27', '%28', '%29', '%2A', '%2B', '%2C', '%3B', '%3D');
         $decoded = array('!', '$', '&', "'", '(', ')', '*', '+', ',', ';', '=');
-        
+
         return str_replace($encoded, $decoded, $str);
     }
-    
+
     /**
      * Is the specified URI string resolvable against the current URI instance?
      */
@@ -245,16 +245,16 @@ class Uri {
         if (!(is_string($toResolve) || method_exists($toResolve, '__toString'))) {
             return false;
         }
-        
+
         try {
             (new Uri($toResolve));
         } catch (\DomainException $e) {
             return false;
         }
-        
+
         return true;
     }
-    
+
     /**
      * @param string $toResolve
      * @return Uri
@@ -266,16 +266,16 @@ class Uri {
         if ($r->__toString() === '') {
             return clone $this;
         }
-        
+
         $base = $this;
-        
+
         $t = new \StdClass;
         $t->scheme = '';
         $t->authority = '';
         $t->path = '';
         $t->query = '';
         $t->fragment = '';
-        
+
         if ('' !== $r->getScheme()) {
             $t->scheme    = $r->getScheme();
             $t->authority = $r->getAuthority();
@@ -306,14 +306,14 @@ class Uri {
             };
             $t->scheme = $base->getScheme();
         };
-        
+
         $t->fragment = $r->getFragment();
-        
+
         $result = $this->reconstitute($t->scheme, $t->authority, $t->path, $t->query, $t->fragment);
-        
+
         return new Uri($result);
     }
-    
+
     /**
      * @link http://tools.ietf.org/html/rfc3986#section-5.2.3
      */
@@ -326,10 +326,10 @@ class Uri {
             $parts[] = $pathToMerge;
             $merged = implode('/', $parts);
         }
-        
+
         return $this->removeDotSegments($merged);
     }
-    
+
     /**
      * @return string
      */
@@ -385,7 +385,7 @@ class Uri {
     public function getFragment() {
         return $this->fragment;
     }
-    
+
     /**
      * Retrieve the URI without the fragment component
      */
@@ -398,21 +398,21 @@ class Uri {
             $fragment = ''
         );
     }
-    
+
     /**
      * @return bool
      */
     public function isIpV4() {
         return $this->isIpV4;
     }
-    
+
     /**
      * @return bool
      */
     public function isIpV6() {
         return $this->isIpV6;
     }
-    
+
     /**
      * @link http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2
      */
@@ -422,29 +422,29 @@ class Uri {
             ? (':' . ($hiddenPass ? '********' : $this->pass))
             : '';
         $authority.= $authority ? '@' : '';
-        
+
         if ($this->isIpV6) {
             $authority.= $this->port ? ("[{$this->host}]:{$this->port}") : "[{$this->host}]";
         } else {
             $authority.= $this->host;
             $authority.= $this->port ? (':' . $this->port) : '';
         }
-        
+
         return $authority;
     }
-    
+
     private function parseQueryParameters() {
         if ($this->query) {
             parse_str(rawurldecode($this->query), $parameters);
-            
+
             $this->queryParameters = $parameters;
             $this->query = str_replace('+', '%20', http_build_query($parameters, null, '&'));
-            
+
             // Fix http_build_query adding equals sign to empty keys
             $this->query = str_replace('=&', '&', rtrim($this->query, '='));
         }
     }
-    
+
     /**
      * @param string $parameter
      * @return bool
@@ -473,7 +473,7 @@ class Uri {
     public function getAllQueryParameters() {
         return $this->queryParameters;
     }
-    
+
     /**
      * @return array
      */

--- a/lib/Uri.php
+++ b/lib/Uri.php
@@ -438,7 +438,7 @@ class Uri {
             parse_str(rawurldecode($this->query), $parameters);
 
             $this->queryParameters = $parameters;
-            $this->query = str_replace('+', '%20', http_build_query($parameters, null, '&'));
+            $this->query = str_replace('+', '%20', http_build_query($parameters, '', '&'));
 
             // Fix http_build_query adding equals sign to empty keys
             $this->query = str_replace('=&', '&', rtrim($this->query, '='));


### PR DESCRIPTION
Horrible branch name not withstanding...

- Removes erroneous whitespace-only lines in Uri
- It is possible in PHP7 with strict types declared to pass null to `http_build_query` resulting in an error. Demonstrated here: https://3v4l.org/M0pJO  This change ensures that a string is always passed