### PR TITLE
Basic proxy auth

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -18,6 +18,8 @@ class Client implements HttpClient {
     const OP_MS_KEEP_ALIVE_TIMEOUT = SocketPool::OP_MS_IDLE_TIMEOUT;
     const OP_PROXY_HTTP = HttpSocketPool::OP_PROXY_HTTP;
     const OP_PROXY_HTTPS = HttpSocketPool::OP_PROXY_HTTPS;
+    const OP_PROXY_HTTP_AUTH = HttpSocketPool::OP_PROXY_HTTP_AUTH;
+    const OP_PROXY_HTTPS_AUTH = HttpSocketPool::OP_PROXY_HTTPS_AUTH;
     const OP_AUTO_ENCODING = 'op.auto-encoding';
     const OP_MS_TRANSFER_TIMEOUT = 'op.ms-transfer-timeout';
     const OP_MS_100_CONTINUE_TIMEOUT = 'op.ms-100-continue-timeout';
@@ -971,6 +973,12 @@ class Client implements HttpClient {
                 break;
             case self::OP_PROXY_HTTPS:
                 $this->options[self::OP_PROXY_HTTPS] = $value;
+                break;
+            case self::OP_PROXY_HTTP_AUTH:
+                $this->options[self::OP_PROXY_HTTP_AUTH] = $value;
+                break;
+            case self::OP_PROXY_HTTPS_AUTH:
+                $this->options[self::OP_PROXY_HTTPS_AUTH] = $value;
                 break;
             case self::OP_CRYPTO:
                 $this->options[self::OP_CRYPTO] = (array) $value;

--- a/lib/HttpSocketPool.php
+++ b/lib/HttpSocketPool.php
@@ -8,7 +8,7 @@ use Amp\Deferred;
 class HttpSocketPool {
     const OP_PROXY_HTTP = 'op.proxy-http';
     const OP_PROXY_HTTPS = 'op.proxy-https';
-    const OP_PROXY_HTTP_AUTH = 'op.proxy-https-auth';
+    const OP_PROXY_HTTP_AUTH = 'op.proxy-http-auth';
     const OP_PROXY_HTTPS_AUTH = 'op.proxy-https-auth';
 
     private $sockPool;

--- a/lib/HttpTunneler.php
+++ b/lib/HttpTunneler.php
@@ -14,7 +14,7 @@ class HttpTunneler {
      * @param string $authority
      * @return \Amp\Promise
      */
-    public function tunnel($socket, $authority, $proxyAuth) {
+    public function tunnel($socket, $authority, $proxyAuth = null) {
         $struct = new HttpTunnelStruct;
         $struct->promisor = new Deferred;
         $struct->socket = $socket;

--- a/lib/HttpTunneler.php
+++ b/lib/HttpTunneler.php
@@ -14,11 +14,12 @@ class HttpTunneler {
      * @param string $authority
      * @return \Amp\Promise
      */
-    public function tunnel($socket, $authority) {
+    public function tunnel($socket, $authority, $proxyAuth) {
         $struct = new HttpTunnelStruct;
         $struct->promisor = new Deferred;
         $struct->socket = $socket;
-        $struct->writeBuffer = "CONNECT {$authority} HTTP/1.1\r\n\r\n";
+        $authHeader = $proxyAuth ? 'Proxy-Authorization: Basic ' . base64_encode($proxyAuth) . "\r\n" : '';
+        $struct->writeBuffer = "CONNECT {$authority} HTTP/1.1\r\n$authHeader\r\n";
         $this->doWrite($struct);
 
         return $struct->promisor->promise();


### PR DESCRIPTION
By basic, I mean minimum viable for basic digest auth.

Does not handle 407 headers, and does not upgrade the underlying proxy framework to be able to use SSL, so passwords are sent in the clear.

Let's call it progress towards #73, but wouldn't call this finished product quality by a long shot.