### PR TITLE
Exposes relevant parser options to client

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,9 @@ A brief summary of the available options follows.
 | OP_COMBINE_COOKIES          | A boolean (default: `true`) controlling whether or not cookie headers are combined into a single header when sending requests. |
 | OP_CRYPTO                   | An array controlling TLS encryption options. |
 | OP_DEFAULT_USER_AGENT       | A string set for each request's User-Agent if a UA has not already been provided. |
+| OP_BODY_SWAP_SIZE           | The size, in bytes, that should be used for body swap. |
+| OP_MAX_HEADER_BYTES         | The maximum size, in bytes, for a Response header. |
+| OP_MAX_BODY_BYTES           | The maximum size, in bytes, for a Response body. |
 
 
 ### Miscellaneous

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -31,6 +31,9 @@ class Client implements HttpClient {
     const OP_COMBINE_COOKIES = 'op.combine-cookies';
     const OP_CRYPTO = 'op.crypto';
     const OP_DEFAULT_USER_AGENT = 'op.default-user-agent';
+    const OP_BODY_SWAP_SIZE = 'op.body-swap-size';
+    const OP_MAX_HEADER_BYTES = 'op.max-header-bytes';
+    const OP_MAX_BODY_BYTES = 'op.max-body-bytes';
 
     const VERBOSE_NONE = 0b00;
     const VERBOSE_SEND = 0b01;
@@ -63,6 +66,9 @@ class Client implements HttpClient {
         self::OP_COMBINE_COOKIES => true,
         self::OP_CRYPTO => [],
         self::OP_DEFAULT_USER_AGENT => null,
+        self::OP_BODY_SWAP_SIZE => Parser::DEFAULT_BODY_SWAP_SIZE,
+        self::OP_MAX_HEADER_BYTES => Parser::DEFAULT_MAX_HEADER_BYTES,
+        self::OP_MAX_BODY_BYTES => Parser::DEFAULT_MAX_BODY_BYTES
     ];
 
     public function __construct(CookieJar $cookieJar = null, HttpSocketPool $socketPool = null, WriterFactory $writerFactory = null) {
@@ -411,9 +417,11 @@ class Client implements HttpClient {
         $parser->enqueueResponseMethodMatch($cycle->request->getMethod());
         $futureResponse = $cycle->futureResponse;
         $parser->setAllOptions([
-            // @TODO Expose a Client::OP_BODY_SWAP_SIZE option
             // @TODO Add support for non-blocking filesystem IO
             Parser::OP_DISCARD_BODY => $cycle->options[self::OP_DISCARD_BODY],
+            Parser::OP_BODY_SWAP_SIZE => $cycle->options[self::OP_BODY_SWAP_SIZE],
+            Parser::OP_MAX_HEADER_BYTES => $cycle->options[self::OP_MAX_HEADER_BYTES],
+            Parser::OP_MAX_BODY_BYTES => $cycle->options[self::OP_MAX_BODY_BYTES],
             Parser::OP_RETURN_BEFORE_ENTITY => true,
             Parser::OP_BODY_DATA_CALLBACK => function($data) use ($futureResponse) {
                 $futureResponse->update([Notify::RESPONSE_BODY_DATA, $data]);
@@ -994,6 +1002,15 @@ class Client implements HttpClient {
                 break;
             case self::OP_DEFAULT_USER_AGENT:
                 $this->options[self::OP_DEFAULT_USER_AGENT] = (string) $value;
+                break;
+            case self::OP_BODY_SWAP_SIZE:
+                $this->options[self::OP_BODY_SWAP_SIZE] = (int) $value;
+                break;
+            case self::OP_MAX_HEADER_BYTES:
+                $this->options[self::OP_MAX_HEADER_BYTES] = (int) $value;
+                break;
+            case self::OP_MAX_BODY_BYTES:
+                $this->options[self::OP_MAX_BODY_BYTES] = (int) $value;
                 break;
             default:
                 throw new \DomainException(

--- a/lib/Parser.php
+++ b/lib/Parser.php
@@ -31,6 +31,10 @@ class Parser {
     const OP_BODY_DATA_CALLBACK = 5;
     const OP_RETURN_BEFORE_ENTITY = 6;
 
+    const DEFAULT_MAX_HEADER_BYTES = 8192;
+    const DEFAULT_MAX_BODY_BYTES = 10485760;
+    const DEFAULT_BODY_SWAP_SIZE = 2097152;
+
     private $mode;
     private $state = self::AWAITING_HEADERS;
     private $buffer = '';
@@ -51,9 +55,9 @@ class Parser {
         'CONTENT-LENGTH' => null
     ];
 
-    private $maxHeaderBytes = 8192;
-    private $maxBodyBytes = 10485760;
-    private $bodySwapSize = 2097152;
+    private $maxHeaderBytes = self::DEFAULT_MAX_HEADER_BYTES;
+    private $maxBodyBytes = self::DEFAULT_MAX_BODY_BYTES;
+    private $bodySwapSize = self::DEFAULT_BODY_SWAP_SIZE;
     private $discardBody = false;
     private $bodyDataCallback;
     private $returnBeforeEntity = false;


### PR DESCRIPTION
The primary use case for this PR is being able to set the `Parser::OP_MAX_BODY_BYTES` option for consuming streaming connections (e.g. the Twitter streaming API). This patch ensures that when handling these types of connections we can configure the Parser appropriately to not check body size. Otherwise after the data limit is hit an error is thrown and the connection is lost.

The rest of the options were added as they seemed relevant (there was a TODO for the body swap size) and it made sense to hit them all at once.