### PR TITLE
Add Notify::HANDSHAKE_COMPLETE

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,9 @@ function myNotifyCallback(array $notifyData) {
         case Amp\Artax\Notify::REDIRECT:
             echo "REDIRECT\n";
             break;
+        case Amp\Artax\Notify::HANDSHAKE_COMPLETE:
+            echo "HANDSHAKE_COMPLETE\n";
+            break;
         case Amp\Artax\Notify::ERROR:
             echo "ERROR\n";
             break;
@@ -372,7 +375,7 @@ $response = Amp\wait($promise);
 
 The following keys are available in the `$update` array sent from the `Progress` object:
 
--  request_state
+- request_state
 - connected_at
 - bytes_rcvd
 - bytes_per_second

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -444,6 +444,9 @@ class Client implements HttpClient {
             }, $timeout);
         }
 
+        $streamMeta = stream_get_meta_data($cycle->socket);
+        $cycle->futureResponse->update([Notify::HANDSHAKE_COMPLETE, $streamMeta]);
+
         $this->writeRequest($cycle);
     }
 

--- a/lib/Notify.php
+++ b/lib/Notify.php
@@ -11,6 +11,6 @@ class Notify {
     const RESPONSE_BODY_DATA = 6;
     const RESPONSE = 7;
     const REDIRECT = 8;
+    const HANDSHAKE_COMPLETE = 9;
     const ERROR = -1;
 }
-


### PR DESCRIPTION
This allows inspecting the stream meta data, e.g. the crypto info. The first
item is as always the Notify ID, the second item is the stream meta data as
returned from `stream_get_meta_data()`. This notification fires always before
a request is written.