### PR TITLE
Check if idleWatcher exists before disabling loop

### DIFF
--- a/lib/SocketPool.php
+++ b/lib/SocketPool.php
@@ -58,13 +58,17 @@ class SocketPool {
                 && ($bindToIp == $options[self::OP_BINDTO])
             ) {
                 $poolStruct->isAvailable = false;
-                Loop::disable($poolStruct->idleWatcher);
+                if (isset($poolStruct->idleWatcher)) {
+                    Loop::disable($poolStruct->idleWatcher);
+                }
                 return $poolStruct->resource;
             } elseif ($bindToIp) {
                 $needsRebind = true;
             } else {
                 $poolStruct->isAvailable = false;
-                Loop::disable($poolStruct->idleWatcher);
+                if (isset($poolStruct->idleWatcher)) {
+                    Loop::disable($poolStruct->idleWatcher);
+                }
 
                 return $poolStruct->resource;
             }


### PR DESCRIPTION
Was getting: 

`TypeError: Argument 1 passed to Amp\Loop::disable() must be of the type string, null given`

not sure why idleWatcher was null, so perhaps there is some other issue that needs fixing, but I did notice that other parts of SocketPool do check the status of idleWatcher before passing it to Loop operations.