### PR TITLE
Allow null content type for multipart form field

### DIFF
--- a/lib/FormBody.php
+++ b/lib/FormBody.php
@@ -33,7 +33,7 @@ final class FormBody implements RequestBody {
      * @param string $value
      * @param string $contentType
      */
-    public function addField(string $name, string $value, string $contentType = '') {
+    public function addField(string $name, string $value, string $contentType = 'text/plain') {
         $this->fields[] = [$name, $value, $contentType, null];
         $this->resetCache();
     }
@@ -44,7 +44,7 @@ final class FormBody implements RequestBody {
      * @param array  $data
      * @param string $contentType
      */
-    public function addFields(array $data, string $contentType = '') {
+    public function addFields(array $data, string $contentType = 'text/plain') {
         foreach ($data as $key => $value) {
             $this->addField($key, $value, $contentType);
         }

--- a/lib/FormBody.php
+++ b/lib/FormBody.php
@@ -33,7 +33,7 @@ final class FormBody implements RequestBody {
      * @param string $value
      * @param string $contentType
      */
-    public function addField(string $name, string $value, string $contentType = 'text/plain') {
+    public function addField(string $name, string $value, ?string $contentType = 'text/plain') {
         $this->fields[] = [$name, $value, $contentType, null];
         $this->resetCache();
     }
@@ -44,7 +44,7 @@ final class FormBody implements RequestBody {
      * @param array  $data
      * @param string $contentType
      */
-    public function addFields(array $data, string $contentType = 'text/plain') {
+    public function addFields(array $data, ?string $contentType = 'text/plain') {
         foreach ($data as $key => $value) {
             $this->addField($key, $value, $contentType);
         }
@@ -122,9 +122,14 @@ final class FormBody implements RequestBody {
         return $header;
     }
 
-    private function generateMultipartFieldHeader(string $name, string $contentType): string {
+    private function generateMultipartFieldHeader(string $name, ?string $contentType): string {
         $header = "Content-Disposition: form-data; name=\"{$name}\"\r\n";
-        $header .= "Content-Type: {$contentType}\r\n\r\n";
+        if ($contentType !== null) {
+	        $header .= "Content-Type: {$contentType}\r\n\r\n";
+        }
+        else {
+	        $header .= "\r\n";
+        }
 
         return $header;
     }

--- a/lib/FormBody.php
+++ b/lib/FormBody.php
@@ -109,7 +109,7 @@ final class FormBody implements RequestBody {
             $fields[] = "\r\n";
         }
 
-        $fields[] = "--{$this->boundary}--";
+        $fields[] = "--{$this->boundary}--\r\n";
 
         return $this->cachedFields = $fields;
     }

--- a/lib/FormBody.php
+++ b/lib/FormBody.php
@@ -33,7 +33,7 @@ final class FormBody implements RequestBody {
      * @param string $value
      * @param string $contentType
      */
-    public function addField(string $name, string $value, ?string $contentType = 'text/plain') {
+    public function addField(string $name, string $value, string $contentType = '') {
         $this->fields[] = [$name, $value, $contentType, null];
         $this->resetCache();
     }
@@ -44,7 +44,7 @@ final class FormBody implements RequestBody {
      * @param array  $data
      * @param string $contentType
      */
-    public function addFields(array $data, ?string $contentType = 'text/plain') {
+    public function addFields(array $data, string $contentType = '') {
         foreach ($data as $key => $value) {
             $this->addField($key, $value, $contentType);
         }
@@ -122,13 +122,12 @@ final class FormBody implements RequestBody {
         return $header;
     }
 
-    private function generateMultipartFieldHeader(string $name, ?string $contentType): string {
+    private function generateMultipartFieldHeader(string $name, string $contentType): string {
         $header = "Content-Disposition: form-data; name=\"{$name}\"\r\n";
-        if ($contentType !== null) {
-	        $header .= "Content-Type: {$contentType}\r\n\r\n";
-        }
-        else {
-	        $header .= "\r\n";
+        if (!empty($contentType)) {
+            $header .= "Content-Type: {$contentType}\r\n\r\n";
+        } else {
+            $header .= "\r\n";
         }
 
         return $header;

--- a/lib/Internal/Parser.php
+++ b/lib/Internal/Parser.php
@@ -179,10 +179,10 @@ final class Parser {
         }
 
         status_line_and_headers: {
-            if (preg_match(self::STATUS_LINE_PATTERN, $startLine, $m)) {
-                $this->protocol = $m['protocol'];
-                $this->responseCode = (int) $m['status'];
-                $this->responseReason = trim($m['reason']);
+            if (preg_match(self::STATUS_LINE_PATTERN, $startLine, $matches)) {
+                $this->protocol = $matches['protocol'];
+                $this->responseCode = (int) $matches['status'];
+                $this->responseReason = trim($matches['reason']);
             } else {
                 throw new ParseException($this->getParsedMessageArray(), 'Invalid status line', 400);
             }

--- a/test/FormBodyTest.php
+++ b/test/FormBodyTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Amp\Artax\Test;
+
+use Amp\Artax\FormBody;
+use Amp\ByteStream\Message;
+use Amp\PHPUnit\TestCase;
+use function Amp\Promise\wait;
+
+class FormBodyTest extends TestCase {
+
+	public function testUrlEncoded() {
+		$body = new FormBody();
+		$body->addFields([
+			'a' => 'a',
+		], 'application/json');
+		$body->addField('b', 'b', 'application/json');
+		$body->addField('c', 'c', '');
+		$body->addField('d', 'd');
+		$body->addFields([
+			'e' => 'e',
+		], '');
+		$body->addFields([
+			'f' => 'f'
+		]);
+		$content = wait($body->createBodyStream()->read());
+		$this->assertEquals("a=a&b=b&c=c&d=d&e=e&f=f", $content);
+	}
+
+	public function testMultiPartFields() {
+		$body = new FormBody('ea4ba2aa9af22673bc01ae7a64c95440');
+		$body->addFields([
+			'a' => 'a',
+		], 'application/json');
+		$body->addField('b', 'b', 'application/json');
+		$body->addField('c', 'c', '');
+		$body->addField('d', 'd');
+		$body->addFields([
+			'e' => 'e',
+		], '');
+		$body->addFields([
+			'f' => 'f'
+		]);
+		$file = __DIR__.'/fixture/lorem.txt';
+		$body->addFile('file', $file);
+		$content = wait(new Message($body->createBodyStream()));
+		$this->assertEquals("--ea4ba2aa9af22673bc01ae7a64c95440\r
+Content-Disposition: form-data; name=\"a\"\r
+Content-Type: application/json\r
+\r
+a\r
+--ea4ba2aa9af22673bc01ae7a64c95440\r
+Content-Disposition: form-data; name=\"b\"\r
+Content-Type: application/json\r
+\r
+b\r
+--ea4ba2aa9af22673bc01ae7a64c95440\r
+Content-Disposition: form-data; name=\"c\"\r
+\r
+c\r
+--ea4ba2aa9af22673bc01ae7a64c95440\r
+Content-Disposition: form-data; name=\"d\"\r
+\r
+d\r
+--ea4ba2aa9af22673bc01ae7a64c95440\r
+Content-Disposition: form-data; name=\"e\"\r
+\r
+e\r
+--ea4ba2aa9af22673bc01ae7a64c95440\r
+Content-Disposition: form-data; name=\"f\"\r
+\r
+f\r
+--ea4ba2aa9af22673bc01ae7a64c95440\r
+Content-Disposition: form-data; name=\"file\"; filename=\"lorem.txt\"\r
+Content-Type: application/octet-stream\r
+Content-Transfer-Encoding: binary\r
+\r
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\r
+--ea4ba2aa9af22673bc01ae7a64c95440--\r\n", $content);
+	}
+
+}

--- a/test/FormBodyTest.php
+++ b/test/FormBodyTest.php
@@ -60,6 +60,7 @@ Content-Disposition: form-data; name=\"c\"\r
 c\r
 --ea4ba2aa9af22673bc01ae7a64c95440\r
 Content-Disposition: form-data; name=\"d\"\r
+Content-Type: text/plain\r
 \r
 d\r
 --ea4ba2aa9af22673bc01ae7a64c95440\r
@@ -68,6 +69,7 @@ Content-Disposition: form-data; name=\"e\"\r
 e\r
 --ea4ba2aa9af22673bc01ae7a64c95440\r
 Content-Disposition: form-data; name=\"f\"\r
+Content-Type: text/plain\r
 \r
 f\r
 --ea4ba2aa9af22673bc01ae7a64c95440\r


### PR DESCRIPTION
Other clients like curl + guzzle don't send a content type for simple multipart form fields. I don't see a reason why a content type is enforced.