### PR TITLE
Avoid single-char vars due to a bug in PHP 7.1.9

### DIFF
--- a/lib/Internal/Parser.php
+++ b/lib/Internal/Parser.php
@@ -179,10 +179,10 @@ final class Parser {
         }
 
         status_line_and_headers: {
-            if (preg_match(self::STATUS_LINE_PATTERN, $startLine, $m)) {
-                $this->protocol = $m['protocol'];
-                $this->responseCode = (int) $m['status'];
-                $this->responseReason = trim($m['reason']);
+            if (preg_match(self::STATUS_LINE_PATTERN, $startLine, $matches)) {
+                $this->protocol = $matches['protocol'];
+                $this->responseCode = (int) $matches['status'];
+                $this->responseReason = trim($matches['reason']);
             } else {
                 throw new ParseException($this->getParsedMessageArray(), 'Invalid status line', 400);
             }


### PR DESCRIPTION
Yes, I am serious. Really. Despite that, avoiding one-char-vars increases code readability

[E_NOTICE] Undefined variable: m in /www/jaumo/vendor/amphp/artax/lib/Internal/Parser.php (Line 184)

Renaming the vars fixes the issue. Don't ask me why but we REALLY have that problem in production!