### PR TITLE
Close sockets correctly for timeouts and incomplete bodies

### DIFF
--- a/lib/Internal/RequestCycle.php
+++ b/lib/Internal/RequestCycle.php
@@ -7,6 +7,7 @@ use Amp\Artax\Response;
 use Amp\CancellationToken;
 use Amp\Deferred;
 use Amp\Emitter;
+use Amp\Socket\ClientSocket;
 use Amp\Struct;
 use Amp\Uri\Uri;
 
@@ -31,8 +32,14 @@ class RequestCycle {
     /** @var Deferred */
     public $deferred;
 
+    /** @var Deferred */
+    public $bodyDeferred;
+
     /** @var Emitter */
     public $body;
+
+    /** @var ClientSocket */
+    public $socket;
 
     /** @var CancellationToken */
     public $cancellation;


### PR DESCRIPTION
Previously the client tried to consume response bodies in case the body
wasn't consumed. That might have left sockets open indefinitely. These
sockets are now closed instead.

Additionally, this commit fixes the transfer timeout, which wasn't
enforced after the headers had been received.

Furthermore, it adds a check that Artax has received the full response
body and the connection wasn't closed pre-maturely.