### PR TITLE
Check against correct state for parser

### DIFF
--- a/lib/DefaultClient.php
+++ b/lib/DefaultClient.php
@@ -289,7 +289,7 @@ final class DefaultClient implements Client {
                         }
                     } while (null !== $chunk = yield $socket->read());
 
-                    if ($parser->getState() !== Parser::AWAITING_HEADERS) {
+                    if ($parser->getState() !== Parser::BODY_IDENTITY_EOF) {
                         throw new HttpException("Incomplete body received.");
                     }
                 }


### PR DESCRIPTION
All tests on `php-http/artax-adapter` fail since this check was added, and IMO it was the wrong constant used when reading the explanation and the code before.

However i may be wrong but this resolve tests failing on `php-http/artax-adapter` library. 

See : https://travis-ci.org/php-http/artax-adapter/builds/288221161