### PR TITLE
Allow unix sockets to be used, fixes #151

### DIFF
--- a/examples/7-unix-sockets.php
+++ b/examples/7-unix-sockets.php
@@ -1,0 +1,58 @@
+<?php
+
+use Amp\Artax\HttpSocketPool;
+use Amp\Artax\Request;
+use Amp\Artax\Response;
+use Amp\CancellationToken;
+use Amp\Loop;
+use Amp\Promise;
+use Amp\Socket\BasicSocketPool;
+use Amp\Socket\ClientSocket;
+use Amp\Socket\SocketPool;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+Loop::run(function () {
+    try {
+        // Unix sockets require a socket pool that changes all URLs to a fixed one.
+        $socketPool = new class implements SocketPool {
+            private $pool;
+
+            public function __construct() {
+                $this->pool = new BasicSocketPool;
+            }
+
+            public function checkout(string $uri, CancellationToken $token = null): Promise {
+                return $this->pool->checkout("unix:///var/run/docker.sock", $token);
+            }
+
+            public function checkin(ClientSocket $socket) {
+                $this->pool->checkin($socket);
+            }
+
+            public function clear(ClientSocket $socket) {
+                $this->pool->clear($socket);
+            }
+        };
+
+        $client = new Amp\Artax\DefaultClient(null, new HttpSocketPool($socketPool));
+
+        $request = new Request('http://docker/info');
+        $promise = $client->request($request);
+
+        /** @var Response $response */
+        $response = yield $promise;
+
+        printf(
+            "HTTP/%s %d %s\n\n",
+            $response->getProtocolVersion(),
+            $response->getStatus(),
+            $response->getReason()
+        );
+
+        $body = yield $response->getBody();
+        print $body . "\n";
+    } catch (Amp\Artax\HttpException $error) {
+        echo $error;
+    }
+});

--- a/lib/DefaultClient.php
+++ b/lib/DefaultClient.php
@@ -1093,7 +1093,7 @@ final class DefaultClient implements Client {
         $crypto = \stream_get_meta_data($socket->getResource())["crypto"] ?? null;
 
         return new ConnectionInfo(
-            $socket->getLocalAddress(),
+            $socket->getLocalAddress() ?? "", // unix sockets don't have a local address
             $socket->getRemoteAddress(),
             $crypto ? TlsInfo::fromMetaData($crypto, \stream_context_get_options($socket->getResource())["ssl"]) : null
         );


### PR DESCRIPTION
We can probably add a `FixedSocketPool` or something like that to `amphp/socket`.