### PR TITLE
Removed unused imports breaking tests

### DIFF
--- a/examples/7-unix-sockets.php
+++ b/examples/7-unix-sockets.php
@@ -3,12 +3,7 @@
 use Amp\Artax\HttpSocketPool;
 use Amp\Artax\Request;
 use Amp\Artax\Response;
-use Amp\CancellationToken;
 use Amp\Loop;
-use Amp\Promise;
-use Amp\Socket\BasicSocketPool;
-use Amp\Socket\ClientSocket;
-use Amp\Socket\SocketPool;
 use Amp\Socket\StaticSocketPool;
 
 require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
Hey, just stumbled upon the failed Travis CI Test due to unused use statements. I just removed them in this PR.