### PR TITLE
Fix unit-test failure in client integration test

### DIFF
--- a/lib/DefaultClient.php
+++ b/lib/DefaultClient.php
@@ -13,6 +13,7 @@ use Amp\Artax\Internal\RequestCycle;
 use Amp\ByteStream\InputStream;
 use Amp\ByteStream\IteratorStream;
 use Amp\ByteStream\Message;
+use Amp\ByteStream\StreamException;
 use Amp\ByteStream\ZlibInputStream;
 use Amp\CancellationToken;
 use Amp\CancelledException;
@@ -491,6 +492,8 @@ final class DefaultClient implements Client {
             }
 
             yield from $this->doRead($requestCycle, $socket, $connectionInfo);
+        } catch (StreamException $e) {
+            throw new SocketException("Failed to write to byte-stream", 0, $e);
         } finally {
             $requestCycle->cancellation->unsubscribe($cancellation);
         }

--- a/test/ClientHttpBinIntegrationTest.php
+++ b/test/ClientHttpBinIntegrationTest.php
@@ -60,7 +60,7 @@ class ClientHttpBinIntegrationTest extends TestCase {
             $promise = $client->request((new Request($uri))->withProtocolVersions(["1.0"]));
 
             $this->expectException(SocketException::class);
-            $this->expectExceptionMessage("Socket disconnected prior to response completion (Parser state: 0)");
+            $this->expectExceptionMessage("Failed to write to byte-stream");
 
             wait($promise);
         } finally {


### PR DESCRIPTION
Currently the test-suite fails since the "server closes socket after accept"-test assumes that results in an error when the response is read. In reality byte-stream already fails on write.

This adds a `catch`-clause for the byte-stream exception, converts it to an artax SocketException and changes the unit-test to expect the correct exception message.