### PR TITLE
Argument 2 passed to Amp\\Artax\\ConnectionInfo::__construct() must b…

### DIFF
--- a/lib/DefaultClient.php
+++ b/lib/DefaultClient.php
@@ -1094,7 +1094,7 @@ final class DefaultClient implements Client {
 
         return new ConnectionInfo(
             $socket->getLocalAddress(),
-            $socket->getRemoteAddress(),
+            $socket->getRemoteAddress() ?? '',
             $crypto ? TlsInfo::fromMetaData($crypto, \stream_context_get_options($socket->getResource())["ssl"]) : null
         );
     }


### PR DESCRIPTION
Argument 2 passed to Amp\\Artax\\ConnectionInfo::__construct() must be of the type string, null given.
In some cases cannon retrieve remote address, method ` $socket->getRemoteAddress()` return null, but for class `ConnectionInfo` second argument must be a string only.