### PR TITLE
Update amphp file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
   - nightly
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "amphp/byte-stream": "^1.1.6",
         "amphp/socket": "^0.10.5",
         "amphp/uri": "^0.1",
-        "amphp/file": "^0.2 || ^0.3",
+        "amphp/file": "^0.2 || ^0.3 || ^1.0",
         "kelunik/certificate": "^1.1"
     },
     "require-dev": {
@@ -44,11 +44,6 @@
     "autoload-dev": {
         "psr-4": {
             "Amp\\Test\\Artax\\": "test"
-        }
-    },
-    "config": {
-        "platform": {
-            "php": "7.0.0"
         }
     }
 }


### PR DESCRIPTION
Updated `amphp/file` dependency to ^1.0.

It's needed to make it possible to require both `amphp/artax` and `amphp/file` in a project without lowering min-stability.